### PR TITLE
Spinner: Encapsulation and White-Box Test

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 	s := &Spinner{
 		done: make(chan struct{}, 1),
 	}
+	fmt.Fprintln(w)
 	go startSpinner(s, d, w)
 	return s
 }
@@ -41,19 +42,18 @@ func (s *Spinner) Stop() {
 }
 
 func startSpinner(s *Spinner, d time.Duration, w io.Writer) {
-	ticker := time.NewTicker(d)
-	fmt.Fprintln(w)
+	t := time.NewTicker(d)
 loop:
 	for {
 		for _, r := range `-\|/` {
 			select {
-			case <-ticker.C:
+			case <-t.C:
 				fmt.Fprintf(w, "\033[F%c\n", r)
 			case <-s.done:
 				break loop
 			}
 		}
 	}
-	ticker.Stop()
+	t.Stop()
 	fmt.Fprintf(w, "\033[F")
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 }
 
 type Spinner struct {
+	t *time.Ticker
 	done chan struct{}
 }
 
@@ -30,11 +31,11 @@ func NewSpinner(d time.Duration) *Spinner {
 
 func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 	s := &Spinner{
+		t: time.NewTicker(d),
 		done: make(chan struct{}, 1),
 	}
 	fmt.Fprintln(w)
-	t := time.NewTicker(d)
-	go startSpinner(s, t, w)
+	go startSpinner(s, w)
 	return s
 }
 
@@ -42,7 +43,8 @@ func (s *Spinner) Stop() {
 	s.done <- struct{}{}
 }
 
-func startSpinner(s *Spinner, t *time.Ticker, w io.Writer) {
+func startSpinner(s *Spinner, w io.Writer) {
+	t := s.t
 loop:
 	for {
 		for _, r := range `-\|/` {

--- a/main.go
+++ b/main.go
@@ -36,8 +36,7 @@ func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 		t:    time.NewTicker(d),
 		done: make(chan struct{}, 1),
 	}
-	fmt.Fprintln(w)
-	go startSpinner(s)
+	startSpinner(s)
 	return s
 }
 
@@ -48,15 +47,16 @@ func (s *Spinner) Stop() {
 }
 
 func startSpinner(s *Spinner) {
-loop:
-	for {
-		for _, r := range `-\|/` {
+	fmt.Fprintln(s.w)
+	go func() {
+	loop:
+		for i := 0; ; i = (i + 1) % 4 {
 			select {
 			case <-s.t.C:
-				fmt.Fprintf(s.w, "\033[F%c\n", r)
+				fmt.Fprintf(s.w, "\033[F%c\n", `-\|/`[i])
 			case <-s.done:
 				break loop
 			}
 		}
-	}
+	}()
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,8 @@ func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 		done: make(chan struct{}, 1),
 	}
 	fmt.Fprintln(w)
-	go startSpinner(s, d, w)
+	t := time.NewTicker(d)
+	go startSpinner(s, t, w)
 	return s
 }
 
@@ -41,8 +42,7 @@ func (s *Spinner) Stop() {
 	s.done <- struct{}{}
 }
 
-func startSpinner(s *Spinner, d time.Duration, w io.Writer) {
-	t := time.NewTicker(d)
+func startSpinner(s *Spinner, t *time.Ticker, w io.Writer) {
 loop:
 	for {
 		for _, r := range `-\|/` {

--- a/main.go
+++ b/main.go
@@ -10,20 +10,45 @@ import (
 
 func main() {
 	file := os.Args[1]
-	go spinner(100 * time.Millisecond)
+	spinner := NewSpinner(100 * time.Millisecond)
 	_, err := exec.Command("djvu2pdf", file).Output()
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("\033[Fconvert %s: DJVU file converted successfully to PDF file\n", file)
+	spinner.Stop()
+	fmt.Printf("convert %s: DJVU file converted successfully to PDF file\n", file)
 }
 
-func spinner(delay time.Duration) {
+type Spinner struct {
+	done chan struct{}
+}
+
+func NewSpinner(d time.Duration) *Spinner {
+	s := &Spinner{
+		done: make(chan struct{}, 1),
+	}
+	go startSpinner(s, d)
+	return s
+}
+
+func (s *Spinner) Stop() {
+	s.done <- struct{}{}
+}
+
+func startSpinner(s *Spinner, d time.Duration) {
+	ticker := time.NewTicker(d)
 	fmt.Println()
+loop:
 	for {
 		for _, r := range `-\|/` {
-			fmt.Printf("\033[F%c\n", r)
-			time.Sleep(delay)
+			select {
+			case <-ticker.C:
+				fmt.Printf("\033[F%c\n", r)
+			case <-s.done:
+				break loop
+			}
 		}
 	}
+	ticker.Stop()
+	fmt.Printf("\033[F")
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ func main() {
 
 type Spinner struct {
 	w    io.Writer
-	t    *time.Ticker
 	done chan struct{}
 }
 
@@ -33,28 +32,28 @@ func NewSpinner(d time.Duration) *Spinner {
 func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 	s := &Spinner{
 		w:    w,
-		t:    time.NewTicker(d),
 		done: make(chan struct{}, 1),
 	}
-	startSpinner(s)
+	startSpinner(s, d)
 	return s
 }
 
 func (s *Spinner) Stop() {
-	s.t.Stop()
 	fmt.Fprintf(s.w, "\033[F")
 	s.done <- struct{}{}
 }
 
-func startSpinner(s *Spinner) {
+func startSpinner(s *Spinner, d time.Duration) {
+	t := time.NewTicker(d)
 	fmt.Fprintln(s.w)
 	go func() {
 	loop:
 		for i := 0; ; i = (i + 1) % 4 {
 			select {
-			case <-s.t.C:
+			case <-t.C:
 				fmt.Fprintf(s.w, "\033[F%c\n", `-\|/`[i])
 			case <-s.done:
+				t.Stop()
 				break loop
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func NewFspinner(w io.Writer, d time.Duration) *Spinner {
 		t:    time.NewTicker(d),
 		done: make(chan struct{}, 1),
 	}
-	fmt.Fprintln(s.w)
-	go startSpinner(s, w)
+	fmt.Fprintln(w)
+	go startSpinner(s)
 	return s
 }
 
@@ -47,13 +47,13 @@ func (s *Spinner) Stop() {
 	s.done <- struct{}{}
 }
 
-func startSpinner(s *Spinner, w io.Writer) {
+func startSpinner(s *Spinner) {
 loop:
 	for {
 		for _, r := range `-\|/` {
 			select {
 			case <-s.t.C:
-				fmt.Fprintf(w, "\033[F%c\n", r)
+				fmt.Fprintf(s.w, "\033[F%c\n", r)
 			case <-s.done:
 				break loop
 			}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -31,8 +31,10 @@ func TestSpinner(t *testing.T) {
 		}
 	}
 	spinner.Stop()
+	// Test tear down escaping
+	expected = fmt.Sprintf("%s\033[F", expected)
 	if rb.String() != expected {
-		t.Errorf("got %q, expected to be unchanged", rb.String())
+		t.Errorf("teardown: got %q, expected %q", rb.String(), expected)
 	}
 	// Now test that the spinner stopped.
 	for i := 0; i < count; i++ {

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -10,10 +10,10 @@ import (
 func TestSpinner(t *testing.T) {
 	count := 10
 	delta := 100 * time.Millisecond
-
 	var rb bytes.Buffer
 	spinner := NewFspinner(&rb, delta)
 	ticker := spinner.t
+
 	expected := "\n"
 	if rb.String() != expected {
 		t.Errorf("got %q, expected immediate newline", rb.String())
@@ -27,7 +27,7 @@ func TestSpinner(t *testing.T) {
 		r := `-\|/`[i%4]
 		expected = fmt.Sprintf("%s\033[F%c\n", expected, r)
 		if rb.String() != expected {
-			t.Errorf("after %d ticks: got %q, expected %q", i, rb.String(), expected)
+			t.Errorf("after %d ticks: got %q, expected %q", i + 1, rb.String(), expected)
 		}
 	}
 	spinner.Stop()

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -12,16 +12,14 @@ func TestSpinner(t *testing.T) {
 	delta := 100 * time.Millisecond
 	var rb bytes.Buffer
 	spinner := NewFspinner(&rb, delta)
-	ticker := spinner.t
 
 	expected := "\n"
 	if rb.String() != expected {
 		t.Errorf("got %q, expected immediate newline", rb.String())
 	}
 	for i := 0; i < count; i++ {
-		// Wait for spinner to pass first.
-		time.Sleep(delta/ 10)
-		<-ticker.C
+		// Let the spinner pass first.
+		time.Sleep(delta * 101/ 100)
 		// Since the terminal is tty, we use ansi escaping to animate
 		// a spinner.
 		r := `-\|/`[i%4]
@@ -44,5 +42,4 @@ func TestSpinner(t *testing.T) {
 			break
 		}
 	}
-	ticker.Stop()
 }

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -40,7 +40,7 @@ func TestSpinner(t *testing.T) {
 	for i := 0; i < count; i++ {
 		time.Sleep(delta)
 		if rb.String() != expected {
-			t.Errorf("Spinner did not shut down: got %q, expected %q", rb.String(), expected)
+			t.Error("Spinner did not shut down")
 			break
 		}
 	}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -11,27 +11,27 @@ func TestSpinner(t *testing.T) {
 	count := 10
 	delta := 100 * time.Millisecond
 
-	spinAt := func(i int) string {
-		r := `-\|/`[i%4]
-		return fmt.Sprintf("%c\n", r)
-	}
-
 	var rb bytes.Buffer
 	spinner := NewFspinner(&rb, delta)
 	ticker := time.NewTicker(delta)
 
-	if rb.String() != "\n" {
+	expected := "\n"
+	if rb.String() != expected {
 		t.Errorf("got %q, expected immediate newline", rb.String())
 	}
 	for i := 0; i < count; i++ {
 		<-ticker.C
-		if rb.String() != spinAt(i) {
-			t.Errorf("got %q after %d ticks, expected %q", rb.String(), i, spinAt(i))
+		// Since the terminal is tty, we use ansi escaping to animate
+		// a spinner.
+		r := `-\|/`[i%4]
+		expected = fmt.Sprintf("%s\033[F%c\n", expected, r)
+		if rb.String() != expected {
+			t.Errorf("got %q after %d ticks, expected %q", rb.String(), i, expected)
 		}
 	}
 	spinner.Stop()
-	if rb.String() != "" {
-		t.Errorf("got %q, expected empty", rb.String())
+	if rb.String() != expected {
+		t.Errorf("got %q, expected to be unchanged", rb.String())
 	}
 	// Now test that the spinner stopped.
 	for i := 0; i < count; i++ {

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSpinner(t *testing.T) {
+	count := 10
+	delta := 100 * time.Millisecond
+
+	spinAt := func(i int) string {
+		r := `-\|/`[i%4]
+		return fmt.Sprintf("%c\n", r)
+	}
+
+	var rb bytes.Buffer
+	spinner := NewFspinner(&rb, delta)
+	ticker := time.NewTicker(delta)
+
+	if rb.String() != "\n" {
+		t.Errorf("got %q, expected immediate newline", rb.String())
+	}
+	for i := 0; i < count; i++ {
+		<-ticker.C
+		if rb.String() != spinAt(i) {
+			t.Errorf("got %q after %d ticks, expected %q", rb.String(), i, spinAt(i))
+		}
+	}
+	spinner.Stop()
+	if rb.String() != "" {
+		t.Errorf("got %q, expected empty", rb.String())
+	}
+	// Now test that the spinner stopped.
+	for i := 0; i < count; i++ {
+		<-ticker.C
+		if rb.String() != "" {
+			t.Error("Spinner did not shut down")
+			break
+		}
+	}
+	ticker.Stop()
+}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -19,7 +19,7 @@ func TestSpinner(t *testing.T) {
 		t.Errorf("got %q, expected immediate newline", rb.String())
 	}
 	for i := 0; i < count; i++ {
-		// Wait for spinner to pass first
+		// Wait for spinner to pass first.
 		time.Sleep(delta/ 10)
 		<-ticker.C
 		// Since the terminal is tty, we use ansi escaping to animate
@@ -31,7 +31,7 @@ func TestSpinner(t *testing.T) {
 		}
 	}
 	spinner.Stop()
-	// Test tear down escaping
+	// Test tear down escaping.
 	expected = fmt.Sprintf("%s\033[F", expected)
 	if rb.String() != expected {
 		t.Errorf("teardown: got %q, expected %q", rb.String(), expected)


### PR DESCRIPTION
Spinner encapsulates printing animation.
Since the terminal is tty, the implementation uses ANSI escaping to animate a spinner. So, it's only white-box testable to confirm the output. Other functionalities are black-box testable so far. 
The scenario of the test is as follows:
- Check setup right after starting a spinner, and before the first tick
- Check if write happens after each duration elapsing, and if the update is as intended (knowing the additional escaping)
- Check teardown after a call to stop, again knowing the necessary escaping

The prearrangement includes
- Reception of interface io.Writer to make a spinner testable.